### PR TITLE
Altera a any_load para que ela considere o método csv2unix2utf8.

### DIFF
--- a/src/ingest-step1-ini.sql
+++ b/src/ingest-step1-ini.sql
@@ -625,7 +625,7 @@ CREATE or replace FUNCTION ingest.any_load(
     msg_ret text;
     num_items bigint;
   BEGIN
-  IF p_method='csv2sql' THEN
+  IF p_method='csv2sql' OR p_method='csv2unix2utf8' THEN
     p_fileref := p_fileref || '.csv';
     -- other checks
   ELSE


### PR DESCRIPTION
Se `any_load` não tratar um método do tipo `csv2unix2utf8`, ela acaba tratando um arquivo `.csv` como se fosse um `.shp`. Então adicionei um `or` para que o teste seja verdadeiro se o método for `csv2unix2utf8` ou `csv2sql`.

Essa situação surge do tratamento de arquivo csv que utiliza CRLF.

Fixes AddressForAll/LIXO-digital-preservation-BR#14
